### PR TITLE
Fix for JRuby expand_path interpretation on windows

### DIFF
--- a/lib/uuid.rb
+++ b/lib/uuid.rb
@@ -169,7 +169,7 @@ class UUID
     if File.writable?(state_dir) then
       @state_file = File.join(state_dir, 'ruby-uuid')
     else
-      @state_file = File.expand_path(File.join('~', '.ruby-uuid'))
+      @state_file = File.expand_path('.ruby-uuid', '~')
     end
 
     @state_file


### PR DESCRIPTION
Running JRuby (1.5.6) on Windows XP interprets:
File.expand_path(File.join('~', '.ruby_uuid')) 
=> "//.ruby_uuid"
while running the same command in MRI ruby:
=> "/.ruby_uuid"

The path yielded by the JRuby interpretation is not recognized by windows.  Using the revised code we get for JRuby:
File.expand_path('.ruby_uuid', '~')
=> "C:/.ruby_uuid"
and for MRI:
=> "/.ruby_uuid"

While this seems to be a bug in JRuby, the revised code can be used as a workaround for the current release.
