### PR TITLE
Safer way to get the version string

### DIFF
--- a/lib/uuid.rb
+++ b/lib/uuid.rb
@@ -60,7 +60,7 @@ class UUID
 
   # Version number.
   module Version
-    version = Gem::Specification.load(File.expand_path("../uuid.gemspec", File.dirname(__FILE__))).version.to_s.split(".").map { |i| i.to_i }
+    version = Gem::SourceIndex.from_installed_gems.find_name('uuid').first.version
     MAJOR = version[0]
     MINOR = version[1]
     PATCH = version[2]


### PR DESCRIPTION
Attempting to reload the gem specification file after Rubygems has already loaded it is redundant and also, with Rubygems 1.5.2, potentially dangerous. For example:

```
irb(main):001:0> require 'rubygems'
false
irb(main):002:0> require 'encoding/character/utf-8'
true
irb(main):003:0> require 'uuid'
TypeError: can't convert Hash into Integer
        from /Users/ballancopatch/.rvm/rubies/ree-1.8.7-2010.02/lib/ruby/site_ruby/1.8/rubygems/specification.rb:509:in `read'
        from /Users/ballancopatch/.rvm/rubies/ree-1.8.7-2010.02/lib/ruby/site_ruby/1.8/rubygems/specification.rb:509:in `load'
        from /Users/ballancopatch/.rvm/gems/ree-1.8.7-2011.01/gems/uuid-2.3.1/lib/uuid.rb:63
        from /Users/ballancopatch/.rvm/rubies/ree-1.8.7-2010.02/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:32:in `gem_original_require'
        from /Users/ballancopatch/.rvm/rubies/ree-1.8.7-2010.02/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:32:in `require'
        from (irb):3
```

(See https://github.com/rubygems/rubygems/pull/47 for more info)
