### PR TITLE
Please pull.

### DIFF
--- a/uuid.gemspec
+++ b/uuid.gemspec
@@ -14,7 +14,6 @@ EOF
   spec.files = Dir['{bin,test,lib,docs}/**/*'] + ['README.rdoc', 'MIT-LICENSE', 'Rakefile', 'CHANGELOG', 'uuid.gemspec']
   spec.executables = "uuid"
   
-  spec.has_rdoc = true
   spec.rdoc_options << '--main' << 'README.rdoc' << '--title' <<  'UUID generator' << '--line-numbers'
                        '--webcvs' << 'http://github.com/assaf/uuid'
   spec.extra_rdoc_files = ['README.rdoc', 'MIT-LICENSE']


### PR DESCRIPTION
I removed the line containing the option 'spec.has_rdoc=true'
in the file uuid.gemspec since it is deprecated and makes Gem whine.

Thanks for your great work!

Best regards, Thomas
