### PR TITLE
Check if ruby-uuid is writable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    uuid (2.3.1)
+    uuid (2.3.2)
       macaddr (~> 1.0)
 
 GEM

--- a/lib/uuid.rb
+++ b/lib/uuid.rb
@@ -167,9 +167,9 @@ class UUID
       state_dir = File.join('', 'var', 'tmp')
     end
 
-    if File.writable?(state_dir) then
-      @state_file = File.join(state_dir, 'ruby-uuid')
-    else
+    @state_file = File.join(state_dir, 'ruby-uuid')
+
+    if !File.writable?(state_dir) || (File.exists?(@state_file) && !File.writabe?(@state_file)) then
       @state_file = File.expand_path('.ruby-uuid', '~')
     end
 


### PR DESCRIPTION
It might have been claimed by another user on the system already. We ran into this issue when deploying multiple apps using uuid on the same system under different accounts. The first app to call uuid wins and the rest all fail (because the file has mod 0644). I just expanded the check a little.
