### PR TITLE
State file mode isn't respected with standard umask

### DIFF
--- a/lib/uuid.rb
+++ b/lib/uuid.rb
@@ -259,6 +259,9 @@ class UUID
       fail "Cannot determine MAC address from any available interface, tried with #{mac_address}" if @mac == 0
       @sequence = rand 0x10000
 
+      # Ensure the mode is respected, even with a restrictive umask
+      File.open(state_file, 'w') { |f| f.chmod(self.class.mode) } if state_file && !File.exists?(state_file)
+
       if state_file
         open_lock 'wb' do |io|
           write_state io

--- a/test/test-uuid.rb
+++ b/test/test-uuid.rb
@@ -17,6 +17,19 @@ class TestUUID < Test::Unit::TestCase
     File.exist?(path)
   end
 
+  def test_state_file_creation_mode
+    UUID.class_eval{ @state_file = nil; @mode = nil }
+    UUID.state_file 0666
+    path = UUID.state_file
+    File.delete path if File.exist?(path)
+
+    old_umask = File.umask(0022)
+    UUID.new.generate
+    File.umask(old_umask)
+
+    assert_equal '0666', sprintf('%04o', File.stat(path).mode & 0777)
+  end
+
   def test_state_file_specify
     path = File.join("path", "to", "ruby-uuid")
     UUID.state_file = path


### PR DESCRIPTION
We need to change the file permissions of the state file to 0666 to allow multiple projects to use the same file.  Our applications run with a standard umask of `0022`.  This prevents us from using

```
UUID.state_file 0666
```

to change the mode.  The umask causes it to become `0644`.

The attached pull request uses `chmod` if the file doesn't exist to ensure the mode is respected.
