### PR TITLE
Small patch to improve class instantiation performance on JRuby

### DIFF
--- a/lib/uuid.rb
+++ b/lib/uuid.rb
@@ -194,6 +194,16 @@ class UUID
     return true if
       uuid =~ /\A(urn:uuid:)?[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}\z/i
   end
+  
+  ##
+  # Uses a system call to interrogate the interfaces for a system address
+  # once. This is cached at the class level to avoid future instances
+  # of the class from having to do a system call. This call is particularly
+  # expensive for JRuby.
+  def self.iee_mac_address
+    @iee_mac_address
+  end
+  @iee_mac_address = Mac.addr.gsub(/:|-/, '').hex & 0x7FFFFFFFFFFF rescue 0
 
   ##
   # Generate a pseudo MAC address because we have no pure-ruby way
@@ -229,11 +239,7 @@ class UUID
   # Uses system calls to get a mac address
   #
   def iee_mac_address
-    begin
-      Mac.addr.gsub(/:|-/, '').hex & 0x7FFFFFFFFFFF
-    rescue
-      0 
-    end
+    self.class.iee_mac_address
   end
 
   ##


### PR DESCRIPTION
It now makes the system call as the class body is being loaded and validated. This value is then returned by a class method.

Performance on JRuby has been improved by several orders of magnitude. It's now competitive with the C-based runtimes that have "cheaper" access to shelling out to a system call.
