### PR TITLE
Manually setting the state_file path sets mode too

### DIFF
--- a/lib/uuid.rb
+++ b/lib/uuid.rb
@@ -114,6 +114,10 @@ class UUID
     @mode
   end
 
+  def self.mode=(mode)
+    @mode = mode
+  end
+
   ##
   # Generates a new UUID string using +format+.  See FORMATS for a list of
   # supported formats.
@@ -185,6 +189,7 @@ class UUID
   # hosts).
   def self.state_file=(path)
     @state_file = path
+    @mode ||= 0644
   end
 
   ##

--- a/test/test-uuid.rb
+++ b/test/test-uuid.rb
@@ -37,6 +37,21 @@ class TestUUID < Test::Unit::TestCase
     assert_equal path, UUID.state_file
   end
 
+  def test_mode_is_set_on_state_file_specify
+    UUID.class_eval{ @state_file = nil; @mode = nil }
+    path = File.join("/tmp", "ruby-uuid-test")
+    File.delete path if File.exist?(path)
+
+    UUID.state_file = path
+
+    old_umask = File.umask(0022)
+    UUID.new.generate
+    File.umask(old_umask)
+
+    UUID.class_eval{ @state_file = nil; @mode = nil }
+    assert_equal '0644', sprintf('%04o', File.stat(path).mode & 0777)
+  end
+
   def test_with_no_state_file
     UUID.state_file = false
     assert !UUID.state_file


### PR DESCRIPTION
When manually setting the state file, set the mode too.
Failure to do so causes an implicit conversion of nil to integer on
first usage.

Also provided a mode method to set the mode explicitly.
