### PR TITLE
For issue #30, use Dir.tmpdir instead of hardcoded /var/tmp path

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -62,7 +62,7 @@ first used by the application, to prevent multiple processes from
 generating the same set of identifiers, and deal with changes to the
 system clock.
 
-The UUID state file is created in <tt>/var/tmp/ruby-uuid</tt> or the Windows
+The UUID state file is created in <tt>#Dir.tmpdir/ruby-uuid</tt> or the Windows
 common application data directory using mode 0644.  If that directory is not
 writable, the file is created as <tt>.ruby-uuid</tt> in the home directory.
 If you need to create the file with a different mode, use UUID#state_file

--- a/lib/uuid.rb
+++ b/lib/uuid.rb
@@ -146,7 +146,7 @@ class UUID
   end
 
   ##
-  # Creates an empty state file in /var/tmp/ruby-uuid or the windows common
+  # Creates an empty state file in #Dir.tmpdir/ruby-uuid or the windows common
   # application data directory using mode 0644.  Call with a different mode
   # before creating a UUID generator if you want to open access beyond your
   # user by default.
@@ -169,7 +169,7 @@ class UUID
 
       state_dir = File.join(path.strip)
     rescue LoadError
-      state_dir = File.join('', 'var', 'tmp')
+      state_dir = Dir.tmpdir
     end
 
     @state_file = File.join(state_dir, 'ruby-uuid')

--- a/test/test-uuid.rb
+++ b/test/test-uuid.rb
@@ -39,7 +39,7 @@ class TestUUID < Test::Unit::TestCase
 
   def test_mode_is_set_on_state_file_specify
     UUID.class_eval{ @state_file = nil; @mode = nil }
-    path = File.join("/tmp", "ruby-uuid-test")
+    path = File.join(Dir.tmpdir, "ruby-uuid-test")
     File.delete path if File.exist?(path)
 
     UUID.state_file = path


### PR DESCRIPTION
On non-windows systems, /var/tmp is used as a hard-coded path for the default state file. Use Dir.tmpdir instead. The path can still be overridden using #UUID::state_file=
