### PR TITLE
Correct user's home directory detection (windows compatibility for ruby >= 1.9.3p362)

### DIFF
--- a/lib/uuid.rb
+++ b/lib/uuid.rb
@@ -176,7 +176,7 @@ class UUID
     @state_file = File.join(state_dir, 'ruby-uuid')
 
     if !File.writable?(state_dir) || (File.exists?(@state_file) && !File.writable?(@state_file)) then
-      @state_file = File.expand_path('.ruby-uuid', '~')
+      @state_file = File.join File.expand_path('~'), '.ruby-uuid'
     end
 
     @state_file


### PR DESCRIPTION
We could use Dir.home instead of this code, but it will not be compatible with old rubies.

(For ruby >= 1.9.3p362 on windows `File.expand_path '.ruby-uuid', '~'` will return `"C:\\current\\app\\path\\~\\.ruby-uuid"`)
