### PR TITLE
Add systemu 2.4.0 to dependencies

### DIFF
--- a/uuid.gemspec
+++ b/uuid.gemspec
@@ -19,4 +19,5 @@ EOF
   s.extra_rdoc_files = ['README.rdoc', 'MIT-LICENSE']
 
   s.add_dependency 'macaddr', ['~>1.0']
+  s.add_dependency 'systemu', ['~>2.4.0']
 end


### PR DESCRIPTION
It's raising an error for systemu dependency. Added systemu 2.4.0 to gemspec.
