### PR TITLE
Change after_fork suggestion to before_fork

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -86,11 +86,11 @@ the following line after disabling the state file:
 
 Note: when using a forking server (Unicorn, Resque, Pipemaster, etc) you don't
 want your forked processes using the same sequence number.  Make sure to
-increment the sequence number each time a worker forks.
+increment the sequence number before each time a worker forks.
 
 For example, in config/unicorn.rb:
 
-  after_fork do |server, worker|
+  before_fork do |server, worker|
     UUID.generator.next_sequence
   end
 

--- a/lib/uuid.rb
+++ b/lib/uuid.rb
@@ -130,9 +130,9 @@ class UUID
 
   ##
   # Returns the UUID generator used by generate.  Useful if you need to mess
-  # with it, e.g. force next sequence when forking (e.g. Unicorn, Resque):
+  # with it, e.g. force next sequence before forking (e.g. Unicorn, Resque):
   #
-  # after_fork do
+  # before_fork do
   #   UUID.generator.next_sequence
   # end
   def self.generator


### PR DESCRIPTION
Changing it in the worker process won't have the desired effect since then all the workers all get the same incremented sequence number. `after_fork` runs in the master process before the fork, so the new sequence number gets inherited in each worker.