### PR TITLE
Use correct variant and version in UUID

### DIFF
--- a/lib/uuid.rb
+++ b/lib/uuid.rb
@@ -84,7 +84,7 @@ class UUID
 
   ##
   # Version number stamped into the UUID to identify it as time-based.
-  VERSION_CLOCK = 0x0100
+  VERSION_CLOCK = 0x1000
 
   ##
   # Formats supported by the UUID generator.
@@ -95,9 +95,9 @@ class UUID
   #                     hyphens
   # <tt>:urn</tt>:: Adds the prefix <tt>urn:uuid:</tt> to the default format
   FORMATS = {
-    :compact => '%08x%04x%04x%04x%012x',
-    :default => '%08x-%04x-%04x-%04x-%012x',
-    :urn     => 'urn:uuid:%08x-%04x-%04x-%04x-%012x',
+    :compact => '%08x%04x%04x%02x%02x%012x',
+    :default => '%08x-%04x-%04x-%02x%02x-%012x',
+    :urn     => 'urn:uuid:%08x-%04x-%04x-%02x%02x-%012x',
   }
 
   ##
@@ -320,7 +320,8 @@ class UUID
         clock        & 0xFFFFFFFF,
        (clock >> 32) & 0xFFFF,
       ((clock >> 48) & 0xFFFF | VERSION_CLOCK),
-      @sequence      & 0xFFFF,
+      (@sequence >> 8) & 0xFF | 0x80,
+      @sequence & 0xFF,
       @mac           & 0xFFFFFFFFFFFF
     ]
   end

--- a/test/test-uuid.rb
+++ b/test/test-uuid.rb
@@ -56,19 +56,19 @@ class TestUUID < Test::Unit::TestCase
     UUID.state_file = false
     assert !UUID.state_file
     uuid = UUID.new
-    assert_match(/\A[\da-f]{32}\z/i, uuid.generate(:compact))
+    assert_match(/\A[\da-f]{12}1[\da-f]{3}[89ab][\da-f]{15}\z/i, uuid.generate(:compact))
     seq = uuid.next_sequence
     assert_equal seq + 1, uuid.next_sequence
     assert !UUID.state_file
   end
 
   def validate_uuid_generator(uuid)
-    assert_match(/\A[\da-f]{32}\z/i, uuid.generate(:compact))
+    assert_match(/\A[\da-f]{12}1[\da-f]{3}[89ab][\da-f]{15}\z/i, uuid.generate(:compact))
 
-    assert_match(/\A[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}\z/i,
+    assert_match(/\A[\da-f]{8}-[\da-f]{4}-1[\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}\z/i,
                  uuid.generate(:default))
 
-    assert_match(/^urn:uuid:[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}\z/i,
+    assert_match(/^urn:uuid:[\da-f]{8}-[\da-f]{4}-1[\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}\z/i,
                  uuid.generate(:urn))
 
     e = assert_raise ArgumentError do
@@ -84,12 +84,12 @@ class TestUUID < Test::Unit::TestCase
   end
 
   def test_class_generate
-    assert_match(/\A[\da-f]{32}\z/i, UUID.generate(:compact))
+    assert_match(/\A[\da-f]{12}1[\da-f]{3}[89ab][\da-f]{15}\z/i, UUID.generate(:compact))
 
-    assert_match(/\A[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}\z/i,
+    assert_match(/\A[\da-f]{8}-[\da-f]{4}-1[\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}\z/i,
                  UUID.generate(:default))
 
-    assert_match(/^urn:uuid:[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}\z/i,
+    assert_match(/^urn:uuid:[\da-f]{8}-[\da-f]{4}-1[\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}\z/i,
                  UUID.generate(:urn))
 
     e = assert_raise ArgumentError do


### PR DESCRIPTION
As pointed out in https://github.com/assaf/uuid/issues/33 , the current implementation does not conform to https://www.ietf.org/rfc/rfc4122.txt with regards to version and variant.

This pull request corrects that by properly setting the variant and version.