### PR TITLE
Follow RFC4122

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,5 @@ end
 
 group :test do
   gem "mocha"
+  gem "test-unit"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,20 @@
 PATH
   remote: .
   specs:
-    uuid (2.3.7)
+    uuid (2.3.9)
       macaddr (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    macaddr (1.6.7)
+    macaddr (1.7.1)
       systemu (~> 2.6.2)
     mocha (0.9.12)
+    power_assert (1.1.4)
     rake (0.8.7)
-    systemu (2.6.4)
+    systemu (2.6.5)
+    test-unit (3.3.1)
+      power_assert
     yard (0.6.7)
 
 PLATFORMS
@@ -20,5 +23,9 @@ PLATFORMS
 DEPENDENCIES
   mocha
   rake
+  test-unit
   uuid!
   yard
+
+BUNDLED WITH
+   1.17.2

--- a/test/test-uuid.rb
+++ b/test/test-uuid.rb
@@ -143,6 +143,28 @@ class TestUUID < Test::Unit::TestCase
     assert_equal foo.sequence + 1, bar.sequence
   end
 
+  def test_uuidv1_fixed_bits
+    uuid = UUID.generate(:default)
+    v = uuid.gsub("-", "").to_i(16)
+    assert_equal(
+      "%x" % [0x00000000_0000_1000_8000_000000000000],
+      "%x" % [0x00000000_0000_f000_c000_000000000000 & v],
+      "unexpected bits in #{uuid}")
+  end
+
+  def test_uuidv1_time_field
+    t1 = Time.now.to_f
+    uuid = UUID.generate(:default)
+    t2 = Time.now.to_f
+    v = uuid.gsub("-", "").to_i(16)
+    time_field = (
+      (((v >> 64) & 0x0fff) << 48) |
+      (((v >> 80) & 0xffff) << 32) |
+      ((v >> 96) & 0xffff_ffff))
+    t = time_field * 1e-7 - 12219292800
+    assert_equal true, (t1 <= t && t <= t2), "invalid time in #{uuid}"
+  end
+
   def test_pseudo_random_mac_address
     uuid_gen = UUID.new
     Mac.stubs(:addr).returns "00:00:00:00:00:00"

--- a/test/test-uuid.rb
+++ b/test/test-uuid.rb
@@ -6,8 +6,8 @@
 
 require 'test/unit'
 require 'rubygems'
-require 'uuid'
-require 'mocha'
+load File.join(File.dirname(__FILE__), '../lib/uuid.rb')
+require 'mocha/test_unit'
 
 class TestUUID < Test::Unit::TestCase
 


### PR DESCRIPTION
This patch improves conformance to RFC4122:
- [4.1.1](https://tools.ietf.org/html/rfc4122#section-4.1.1) Octet 8 is 0b10xxxxxx (the variant specified in the RFC).
- [4.1.3](https://tools.ietf.org/html/rfc4122#section-4.1.3) Octet 6 is 0b0001xxxx (version 1, time-based).
- [4.1.4](https://tools.ietf.org/html/rfc4122#section-4.1.4) Time field is 60 bits counting 100ns since UUID epoch (1582-10-15).
- [4.1.5](https://tools.ietf.org/html/rfc4122#section-4.1.5) Clock sequence is 14 bits since it's multiplexed with variant.

Existing implementation before this patch:
- Octet 8 could be anything.
- Octet 6 was 0bxxxxxxx1.
- Time field was 64 bits counting 100ns since Unix epoch (1970-01-01).
- Clock sequence was 16 bits.