### PR TITLE
Mocha 2.0+ compatibility

### DIFF
--- a/test/test-uuid.rb
+++ b/test/test-uuid.rb
@@ -7,7 +7,7 @@
 require 'test/unit'
 require 'rubygems'
 require 'uuid'
-require 'mocha'
+require 'mocha/test_unit'
 
 class TestUUID < Test::Unit::TestCase
 


### PR DESCRIPTION
The support for `require 'mocha/setup'` is long time deprecated and was removed in Mocha 2.0:

https://github.com/freerange/mocha/commit/642a0ff4

Fixes #43 